### PR TITLE
Fix Uno Penalty Repeats on Draw Action

### DIFF
--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -599,7 +599,8 @@ function HideUNO()
     --If someone else other than the player with UNO pressed the button, uno_Called will be true, so we should deal 2 cards to the player with UNO
     if uno_Called == true
     then
-        DealCardsToColor(2,color_Has_Uno)   
+        uno_Called = false
+        DealCardsToColor(2,color_Has_Uno)
     end
     uno_Button_Visible = false
     UI.hide("UNO_Button")


### PR DESCRIPTION
When "HideUNO()" is called in the "DrawCard()", it repeats the draw penalty. This fix clears the "uno_Called" variable at the time the penalty is met, so subsequent calls will not repeat the penalty.